### PR TITLE
Fix promotion healing

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -1,5 +1,4 @@
 // TODO: Add column/rows to each promotion?
-// TODO: Make "[This Unit] heals [25] HP <hidden from users>" heal only half of the missing HP
 [
 	{
 		"name": "Accuracy",

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -5,8 +5,7 @@
 		"name": "Accuracy",
 		"prerequisites": ["City Raider I", "Barrage I"],
 		"uniques": [
-			"[+8]% Strength <vs cities>", // +8% City Bombard Damage
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+8]% Strength <vs cities>" // +8% City Bombard Damage
 		],
 		"unitTypes": ["Siege"],
 		"outerColor": [12, 74, 146],
@@ -16,8 +15,7 @@
 		"name": "Ambush",
 		"prerequisites": ["Combat II"],
 		"uniques": [
-			"[+25]% Strength <vs [Armored] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength <vs [Armored] units>"
 		],
 		"unitTypes": ["Gunpowder", "Siege", "Armored", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -28,8 +26,7 @@
 		"prerequisites": ["Combat II"],
 		"uniques": [
 			"Eliminates combat penalty for attacking over a river",
-			"Eliminates combat penalty for attacking across a coast",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Eliminates combat penalty for attacking across a coast"
 		],
 		"unitTypes": ["Scout","Archery","Gunpowder", "Sword", "Mounted", "Siege"],
 		"outerColor": [12, 74, 146],
@@ -38,8 +35,7 @@
 	{
 		"name": "Barrage I",
 		"uniques": [
-			"[+10]% Strength", // +20% Collateral Damage
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength" // +20% Collateral Damage
 		],
 		"unitTypes": ["Siege", "Armored", "Ranged Water", "Melee Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -50,8 +46,7 @@
 		"prerequisites": ["Barrage I"],
 		"uniques": [
 			"[+15]% Strength", // +30% Collateral Damage
-			"[+10]% Strength <vs [Melee] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength <vs [Melee] units>"
 		],
 		"unitTypes": ["Siege", "Armored", "Ranged Water", "Melee Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -63,8 +58,7 @@
 		"uniques": [
 			"[+25]% Strength", // +50% Collateral Damage
 			"[+10]% Strength <vs [Gunpowder] units>",
-			"[+10]% Strength <vs [Ranged Gunpowder] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength <vs [Ranged Gunpowder] units>"
 		],
 		"unitTypes": ["Siege", "Armored", "Ranged Water", "Melee Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -75,8 +69,7 @@
 		"prerequisites": ["Combat III"],
 		"uniques": [
 			"[1] additional attacks per turn",
-			"Only available <after discovering [Chemistry]>", // Military Science in BTS
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Only available <after discovering [Chemistry]>" // Military Science in BTS
 		],
 		"unitTypes": ["Mounted", "Armored", "Helicopter", "Melee Water"],
 		"outerColor": [12, 74, 146],
@@ -86,8 +79,7 @@
 		"name": "Charge",
 		"prerequisites": ["Combat I"],
 		"uniques": [
-			"[+25]% Strength <vs [Siege] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength <vs [Siege] units>"
 		],
 		"unitTypes": ["Sword","Mounted", "Armored", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -96,8 +88,7 @@
 	{
 		"name": "City Garrison I",
 		"uniques": [
-			"[+20]% Strength <in [in all cities] cities> <when defending>", // +20% city Defense
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+20]% Strength <in [in all cities] cities> <when defending>" // +20% city Defense
 		],
 		"unitTypes": ["Archery", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -108,8 +99,7 @@
 		"prerequisites": ["City Garrison I"],
 		"uniques": [
 			"[+30]% Strength <in [in all cities] cities> <when defending>", // +30% city Defense
-			"[+10]% Strength <vs [Melee] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength <vs [Melee] units>"
 		],
 		"unitTypes": ["Archery", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -120,8 +110,7 @@
 		"prerequisites": ["City Garrison II"],
 		"uniques": [
 			"[+30]% Strength <in [in all cities] cities> <when defending>", // +30% city Defense
-			"[+10]% Strength <vs [Melee] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength <vs [Melee] units>"
 		],
 		"unitTypes": ["Archery", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -130,8 +119,7 @@
 	{
 		"name": "City Raider I",
 		"uniques": [
-			"[+20]% Strength <vs cities>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+20]% Strength <vs cities>"
 		],
 		"unitTypes": ["Melee Water", "Sword", "Scout", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -141,8 +129,7 @@
 		"name": "City Raider II",
 		"prerequisites": ["City Raider I"],
 		"uniques": [
-			"[+25]% Strength <vs cities>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength <vs cities>"
 		],
 		"unitTypes": ["Melee Water", "Sword", "Scout", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -154,8 +141,7 @@
 		"uniques": [
 			"[+30]% Strength <vs cities>",
 			"[+10]% Strength <vs [Ranged Gunpowder] units>",
-			"[+10]% Strength <vs [Gunpowder] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength <vs [Gunpowder] units>"
 		],
 		"unitTypes": ["Melee Water", "Sword", "Scout", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -164,8 +150,7 @@
 	{
 		"name": "Combat I",
 		"uniques": [
-			"[+10]% Strength",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -175,8 +160,7 @@
 		"name": "Combat II",
 		"prerequisites": ["Combat I"],
 		"uniques": [
-			"[+10]% Strength",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -186,8 +170,7 @@
 		"name": "Combat III",
 		"prerequisites": ["Combat II"],
 		"uniques": [
-			"[+10]% Strength",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% Strength"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -198,8 +181,7 @@
 		"prerequisites": ["Combat III"],
 		"uniques": [
 			"[+10]% Strength",
-			"May heal outside of friendly territory", // Heals extra 10% damage per turn in neutral lands
-			"[This Unit] heals [25] HP <hidden from users>"
+			"May heal outside of friendly territory" // Heals extra 10% damage per turn in neutral lands
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -210,8 +192,7 @@
 		"prerequisites": ["Combat IV"],
 		"uniques": [
 			"[+10]% Strength",
-			"Unit will heal every turn, even if it performs an action", // Heals extra 10% damage per turn in enemy lands
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Unit will heal every turn, even if it performs an action" // Heals extra 10% damage per turn in enemy lands
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -221,8 +202,7 @@
 		"name": "Combat VI",
 		"prerequisites": ["Combat V"],
 		"uniques": [
-			"[+25]% Strength",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -235,8 +215,7 @@
 			// Can use enemy roads and railroads
 			"[1] Movement <in [Road] tiles> <on foreign continents>",
 			"[2] Movement <in [Railroad] tiles> <on foreign continents>",
-			"Only available <after discovering [Chemistry]>", // Military Science in BTS
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Only available <after discovering [Chemistry]>" // Military Science in BTS
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -246,8 +225,7 @@
 		"name": "Cover",
 		"prerequisites": ["Combat I"],
 		"uniques": [
-			"[+25]% Strength <vs [Archery] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength <vs [Archery] units>"
 		],
 		"unitTypes": ["Archery","Gunpowder", "Sword"],
 		"outerColor": [12, 74, 146],
@@ -256,8 +234,7 @@
 	{
 		"name": "Drill I",
 		"uniques": [
-			"[+10]% to Flank Attack bonuses", // TODO: +1 first strike chance
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+10]% to Flank Attack bonuses" // TODO: +1 first strike chance
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -267,9 +244,8 @@
 		"name": "Drill II",
 		"prerequisites": ["Drill I"],
 		"uniques": [
-			"[+15]% to Flank Attack bonuses", // +1 first strike chance
+			"[+15]% to Flank Attack bonuses" // +1 first strike chance
 			// Suffers 20% less collateral damage
-			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -278,8 +254,7 @@
 	{
 		"name": "Flanking I",
 		"uniques": [
-			"Withdraws before melee combat <with [10]% chance>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Withdraws before melee combat <with [10]% chance>"
 		],
 		"unitTypes": ["Mounted", "Armored", "Submarine", "Ranged Water", "Melee Water", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -290,8 +265,7 @@
 		"prerequisites": ["Flanking I"],
 		"uniques": [
 			// Immune to first strikes
-			"Withdraws before melee combat <with [20]% chance>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Withdraws before melee combat <with [20]% chance>"
 		],
 		"unitTypes": ["Mounted", "Armored", "Submarine", "Ranged Water", "Melee Water", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -302,8 +276,7 @@
 		"prerequisites": ["Combat II", "Drill II"],
 		"uniques": [
 			// Immune to first strikes
-			"[+25]% Strength <vs [Mounted] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength <vs [Mounted] units>"
 		],
 		"unitTypes": ["Archery", "Mounted", "Sword", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -312,8 +285,7 @@
 	{
 		"name": "Guerrilla I",
 		"uniques": [
-			"[+20]% Strength <when fighting in [Hill] tiles> <when defending>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+20]% Strength <when fighting in [Hill] tiles> <when defending>"
 		],
 		"unitTypes": ["Scout","Archery","Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -324,10 +296,9 @@
 		"prerequisites": ["Guerrilla I"],
 		"uniques": [
 			"[+30]% Strength <when fighting in [Hill] tiles> <when defending>",
-			"Double movement in [Hill]",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Double movement in [Hill]"
 		],
-		"unitTypes": ["Scout","Archery","Gunpowder", "Sword"] // Yes melee gets it even though they can't have the initial one, see https://civilization.fandom.com/wiki/Guerrilla_(Civ4)#Guerrilla_II,
+		"unitTypes": ["Scout","Archery","Gunpowder", "Sword"], // Yes melee gets it even though they can't have the initial one, see https://civilization.fandom.com/wiki/Guerrilla_(Civ4)#Guerrilla_II,
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
 	},
@@ -337,8 +308,7 @@
 		"uniques": [
 			"[+25]% Strength <when fighting in [Hill] tiles> <when attacking>",
 			"Double movement in [Hill]",
-			"Withdraws before melee combat <with [50]% chance>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Withdraws before melee combat <with [50]% chance>"
 		],
 		"unitTypes": ["Scout","Archery","Gunpowder", "Sword"],
 		"outerColor": [12, 74, 146],
@@ -348,8 +318,7 @@
 		"name": "March",
 		"prerequisites": ["Combat III", "Medic I"],
 		"uniques": [
-			"May heal outside of friendly territory",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"May heal outside of friendly territory"
 		],
 		"unitTypes": ["Scout", "Archery", "Mounted", "Sword", "Siege", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -359,8 +328,7 @@
 		"name": "Medic I",
 		"prerequisites": ["Combat I"],
 		"uniques": [
-			"All adjacent units heal [+10] HP when healing", // Heal units in same tile +10%/turn
-			"[This Unit] heals [25] HP <hidden from users>"
+			"All adjacent units heal [+10] HP when healing" // Heal units in same tile +10%/turn
 		],
 		"unitTypes": ["Scout","Mounted", "Sword", "Archery", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -370,8 +338,7 @@
 		"name": "Medic II",
 		"prerequisites": ["Medic I"],
 		"uniques": [
-			"All adjacent units heal [+10] HP when healing", // Heal units in same tile +10%/turn
-			"[This Unit] heals [25] HP <hidden from users>"
+			"All adjacent units heal [+10] HP when healing" // Heal units in same tile +10%/turn
 		],
 		"unitTypes": ["Scout","Mounted", "Sword", "Archery", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -381,8 +348,7 @@
 		"name": "Mobility",
 		"prerequisites": ["Flanking II"],
 		"uniques": [
-			"[+1] Movement", // -1 terrain movement cost
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+1] Movement" // -1 terrain movement cost
 		],
 		"unitTypes": ["Mounted", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -392,8 +358,7 @@
 		"name": "Navigation I",
 		"prerequisites": ["Flanking I"],
 		"uniques": [
-			"[+1] Movement",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+1] Movement"
 		],
 		"unitTypes": ["Melee Water", "Ranged Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -403,8 +368,7 @@
 		"name": "Navigation II",
 		"prerequisites": ["Navigation I"],
 		"uniques": [
-			"[+1] Movement",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+1] Movement"
 		],
 		"unitTypes": ["Melee Water", "Ranged Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -416,8 +380,7 @@
 		"uniques": [
 			"[+25]% Strength <vs [Gunpowder] units>",
 			"[+25]% Strength <vs [Ranged Gunpowder] units>",
-			"Only available <after discovering [Gunpowder]>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Only available <after discovering [Gunpowder]>"
 		],
 		"unitTypes": ["Mounted", "Gunpowder", "Ranged Gunpowder", "Armored", "Helicopter", "Fighter", "Bomber", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -427,8 +390,7 @@
 		"name": "Sentry",
 		"prerequisites": ["Combat III", "Flanking I"],
 		"uniques": [
-			"[+1] Sight",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+1] Sight"
 		],
 		"unitTypes": ["Mounted", "Scout", "Helicopter", "Melee Water"],
 		"outerColor": [12, 74, 146],
@@ -438,8 +400,7 @@
 		"name": "Shock",
 		"prerequisites": ["Combat I", "Drill I"],
 		"uniques": [
-			"[+25]% Strength <vs [Melee] units>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+25]% Strength <vs [Melee] units>"
 		],
 		"unitTypes": ["Archery", "Mounted", "Sword", "Siege"],
 		"outerColor": [12, 74, 146],
@@ -449,8 +410,7 @@
 		"name": "Woodsman I",
 		"uniques": [
 			"[+20]% Strength <when fighting in [Jungle] tiles> <when defending>",
-			"[+20]% Strength <when fighting in [Forest] tiles> <when defending>",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"[+20]% Strength <when fighting in [Forest] tiles> <when defending>"
 		],
 		"unitTypes": ["Scout", "Sword", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -463,8 +423,7 @@
 			"[+30]% Strength <when fighting in [Jungle] tiles> <when defending>",
 			"[+30]% Strength <when fighting in [Forest] tiles> <when defending>",
 			"Double movement in [Jungle]",
-			"Double movement in [Forest]",
-			"[This Unit] heals [25] HP <hidden from users>"
+			"Double movement in [Forest]"
 		],
 		"unitTypes": ["Scout", "Sword", "Gunpowder"],
 		"outerColor": [12, 74, 146],

--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -1,10 +1,12 @@
 // TODO: Add column/rows to each promotion?
+// TODO: Make "[This Unit] heals [25] HP <hidden from users>" heal only half of the missing HP
 [
 	{
 		"name": "Accuracy",
 		"prerequisites": ["City Raider I", "Barrage I"],
 		"uniques": [
-			"[+8]% Strength <vs cities>" // +8% City Bombard Damage
+			"[+8]% Strength <vs cities>", // +8% City Bombard Damage
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Siege"],
 		"outerColor": [12, 74, 146],
@@ -13,7 +15,10 @@
 	{
 		"name": "Ambush",
 		"prerequisites": ["Combat II"],
-		"uniques": ["[+25]% Strength <vs [Armored] units>"],
+		"uniques": [
+			"[+25]% Strength <vs [Armored] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Gunpowder", "Siege", "Armored", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -23,7 +28,8 @@
 		"prerequisites": ["Combat II"],
 		"uniques": [
 			"Eliminates combat penalty for attacking over a river",
-			"Eliminates combat penalty for attacking across a coast"
+			"Eliminates combat penalty for attacking across a coast",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Scout","Archery","Gunpowder", "Sword", "Mounted", "Siege"],
 		"outerColor": [12, 74, 146],
@@ -32,7 +38,8 @@
 	{
 		"name": "Barrage I",
 		"uniques": [
-			"[+10]% Strength" // +20% Collateral Damage
+			"[+10]% Strength", // +20% Collateral Damage
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Siege", "Armored", "Ranged Water", "Melee Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -43,7 +50,8 @@
 		"prerequisites": ["Barrage I"],
 		"uniques": [
 			"[+15]% Strength", // +30% Collateral Damage
-			"[+10]% Strength <vs [Melee] units>"
+			"[+10]% Strength <vs [Melee] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Siege", "Armored", "Ranged Water", "Melee Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -55,7 +63,8 @@
 		"uniques": [
 			"[+25]% Strength", // +50% Collateral Damage
 			"[+10]% Strength <vs [Gunpowder] units>",
-			"[+10]% Strength <vs [Ranged Gunpowder] units>"
+			"[+10]% Strength <vs [Ranged Gunpowder] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Siege", "Armored", "Ranged Water", "Melee Water", "Submarine"],
 		"outerColor": [12, 74, 146],
@@ -66,7 +75,8 @@
 		"prerequisites": ["Combat III"],
 		"uniques": [
 			"[1] additional attacks per turn",
-			"Only available <after discovering [Chemistry]>" // Military Science in BTS
+			"Only available <after discovering [Chemistry]>", // Military Science in BTS
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Mounted", "Armored", "Helicopter", "Melee Water"],
 		"outerColor": [12, 74, 146],
@@ -75,7 +85,10 @@
 	{
 		"name": "Charge",
 		"prerequisites": ["Combat I"],
-		"uniques": ["[+25]% Strength <vs [Siege] units>"],
+		"uniques": [
+			"[+25]% Strength <vs [Siege] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Sword","Mounted", "Armored", "Helicopter"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -83,7 +96,8 @@
 	{
 		"name": "City Garrison I",
 		"uniques": [
-			"[+20]% Strength <in [in all cities] cities> <when defending>" // +20% city Defense
+			"[+20]% Strength <in [in all cities] cities> <when defending>", // +20% city Defense
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Archery", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -94,7 +108,8 @@
 		"prerequisites": ["City Garrison I"],
 		"uniques": [
 			"[+30]% Strength <in [in all cities] cities> <when defending>", // +30% city Defense
-			"[+10]% Strength <vs [Melee] units>"
+			"[+10]% Strength <vs [Melee] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Archery", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -105,7 +120,8 @@
 		"prerequisites": ["City Garrison II"],
 		"uniques": [
 			"[+30]% Strength <in [in all cities] cities> <when defending>", // +30% city Defense
-			"[+10]% Strength <vs [Melee] units>"
+			"[+10]% Strength <vs [Melee] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Archery", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -114,7 +130,8 @@
 	{
 		"name": "City Raider I",
 		"uniques": [
-			"[+20]% Strength <vs cities>"
+			"[+20]% Strength <vs cities>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Melee Water", "Sword", "Scout", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -124,7 +141,8 @@
 		"name": "City Raider II",
 		"prerequisites": ["City Raider I"],
 		"uniques": [
-			"[+25]% Strength <vs cities>"
+			"[+25]% Strength <vs cities>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Melee Water", "Sword", "Scout", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -136,7 +154,8 @@
 		"uniques": [
 			"[+30]% Strength <vs cities>",
 			"[+10]% Strength <vs [Ranged Gunpowder] units>",
-			"[+10]% Strength <vs [Gunpowder] units>"
+			"[+10]% Strength <vs [Gunpowder] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Melee Water", "Sword", "Scout", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -145,7 +164,8 @@
 	{
 		"name": "Combat I",
 		"uniques": [
-			"[+10]% Strength"
+			"[+10]% Strength",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -155,7 +175,8 @@
 		"name": "Combat II",
 		"prerequisites": ["Combat I"],
 		"uniques": [
-			"[+10]% Strength"
+			"[+10]% Strength",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -165,7 +186,8 @@
 		"name": "Combat III",
 		"prerequisites": ["Combat II"],
 		"uniques": [
-			"[+10]% Strength"
+			"[+10]% Strength",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -176,7 +198,8 @@
 		"prerequisites": ["Combat III"],
 		"uniques": [
 			"[+10]% Strength",
-			"May heal outside of friendly territory" // Heals extra 10% damage per turn in neutral lands
+			"May heal outside of friendly territory", // Heals extra 10% damage per turn in neutral lands
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -187,7 +210,8 @@
 		"prerequisites": ["Combat IV"],
 		"uniques": [
 			"[+10]% Strength",
-			"Unit will heal every turn, even if it performs an action" // Heals extra 10% damage per turn in enemy lands
+			"Unit will heal every turn, even if it performs an action", // Heals extra 10% damage per turn in enemy lands
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -197,7 +221,8 @@
 		"name": "Combat VI",
 		"prerequisites": ["Combat V"],
 		"uniques": [
-			"[+25]% Strength"
+			"[+25]% Strength",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored", "Melee Water", "Ranged Water", "Submarine", "Fighter", "Helicopter", "Bomber"],
 		"outerColor": [12, 74, 146],
@@ -210,7 +235,8 @@
 			// Can use enemy roads and railroads
 			"[1] Movement <in [Road] tiles> <on foreign continents>",
 			"[2] Movement <in [Railroad] tiles> <on foreign continents>",
-			"Only available <after discovering [Chemistry]>" // Military Science in BTS
+			"Only available <after discovering [Chemistry]>", // Military Science in BTS
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder", "Scout", "Mounted", "Armored"],
 		"outerColor": [12, 74, 146],
@@ -219,7 +245,10 @@
 	{
 		"name": "Cover",
 		"prerequisites": ["Combat I"],
-		"uniques": ["[+25]% Strength <vs [Archery] units>"],
+		"uniques": [
+			"[+25]% Strength <vs [Archery] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Archery","Gunpowder", "Sword"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -227,7 +256,8 @@
 	{
 		"name": "Drill I",
 		"uniques": [
-			"[+10]% to Flank Attack bonuses" // TODO: +1 first strike chance
+			"[+10]% to Flank Attack bonuses", // TODO: +1 first strike chance
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -237,8 +267,9 @@
 		"name": "Drill II",
 		"prerequisites": ["Drill I"],
 		"uniques": [
-			"[+15]% to Flank Attack bonuses" // +1 first strike chance
+			"[+15]% to Flank Attack bonuses", // +1 first strike chance
 			// Suffers 20% less collateral damage
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Sword", "Gunpowder", "Archery", "Ranged Gunpowder", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -247,7 +278,8 @@
 	{
 		"name": "Flanking I",
 		"uniques": [
-			"Withdraws before melee combat <with [10]% chance>"
+			"Withdraws before melee combat <with [10]% chance>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Mounted", "Armored", "Submarine", "Ranged Water", "Melee Water", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -258,7 +290,8 @@
 		"prerequisites": ["Flanking I"],
 		"uniques": [
 			// Immune to first strikes
-			"Withdraws before melee combat <with [20]% chance>"
+			"Withdraws before melee combat <with [20]% chance>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Mounted", "Armored", "Submarine", "Ranged Water", "Melee Water", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -269,7 +302,8 @@
 		"prerequisites": ["Combat II", "Drill II"],
 		"uniques": [
 			// Immune to first strikes
-			"[+25]% Strength <vs [Mounted] units>"
+			"[+25]% Strength <vs [Mounted] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Archery", "Mounted", "Sword", "Gunpowder", "Ranged Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -277,7 +311,10 @@
 	},
 	{
 		"name": "Guerrilla I",
-		"uniques": ["[+20]% Strength <when fighting in [Hill] tiles> <when defending>"],
+		"uniques": [
+			"[+20]% Strength <when fighting in [Hill] tiles> <when defending>",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Scout","Archery","Gunpowder"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -287,7 +324,8 @@
 		"prerequisites": ["Guerrilla I"],
 		"uniques": [
 			"[+30]% Strength <when fighting in [Hill] tiles> <when defending>",
-			"Double movement in [Hill]"
+			"Double movement in [Hill]",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Scout","Archery","Gunpowder", "Sword"] // Yes melee gets it even though they can't have the initial one, see https://civilization.fandom.com/wiki/Guerrilla_(Civ4)#Guerrilla_II,
 		"outerColor": [12, 74, 146],
@@ -299,7 +337,8 @@
 		"uniques": [
 			"[+25]% Strength <when fighting in [Hill] tiles> <when attacking>",
 			"Double movement in [Hill]",
-			"Withdraws before melee combat <with [50]% chance>"
+			"Withdraws before melee combat <with [50]% chance>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Scout","Archery","Gunpowder", "Sword"],
 		"outerColor": [12, 74, 146],
@@ -308,7 +347,10 @@
 	{
 		"name": "March",
 		"prerequisites": ["Combat III", "Medic I"],
-		"uniques": ["May heal outside of friendly territory"],
+		"uniques": [
+			"May heal outside of friendly territory",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Scout", "Archery", "Mounted", "Sword", "Siege", "Gunpowder"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -316,7 +358,10 @@
 	{
 		"name": "Medic I",
 		"prerequisites": ["Combat I"],
-		"uniques": ["All adjacent units heal [+10] HP when healing"], // Heal units in same tile +10%/turn
+		"uniques": [
+			"All adjacent units heal [+10] HP when healing", // Heal units in same tile +10%/turn
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Scout","Mounted", "Sword", "Archery", "Gunpowder"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -324,7 +369,10 @@
 	{
 		"name": "Medic II",
 		"prerequisites": ["Medic I"],
-		"uniques": ["All adjacent units heal [+10] HP when healing"], // Heal units in same tile +10%/turn
+		"uniques": [
+			"All adjacent units heal [+10] HP when healing", // Heal units in same tile +10%/turn
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Scout","Mounted", "Sword", "Archery", "Gunpowder"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -332,7 +380,10 @@
 	{
 		"name": "Mobility",
 		"prerequisites": ["Flanking II"],
-		"uniques": ["[+1] Movement"], // -1 terrain movement cost
+		"uniques": [
+			"[+1] Movement", // -1 terrain movement cost
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Mounted", "Armored"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -340,7 +391,10 @@
 	{
 		"name": "Navigation I",
 		"prerequisites": ["Flanking I"],
-		"uniques": ["[+1] Movement"],
+		"uniques": [
+			"[+1] Movement",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Melee Water", "Ranged Water", "Submarine"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -348,7 +402,10 @@
 	{
 		"name": "Navigation II",
 		"prerequisites": ["Navigation I"],
-		"uniques": ["[+1] Movement"],
+		"uniques": [
+			"[+1] Movement",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Melee Water", "Ranged Water", "Submarine"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -359,7 +416,8 @@
 		"uniques": [
 			"[+25]% Strength <vs [Gunpowder] units>",
 			"[+25]% Strength <vs [Ranged Gunpowder] units>",
-			"Only available <after discovering [Gunpowder]>"
+			"Only available <after discovering [Gunpowder]>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Mounted", "Gunpowder", "Ranged Gunpowder", "Armored", "Helicopter", "Fighter", "Bomber", "Helicopter"],
 		"outerColor": [12, 74, 146],
@@ -368,7 +426,10 @@
 	{
 		"name": "Sentry",
 		"prerequisites": ["Combat III", "Flanking I"],
-		"uniques": ["[+1] Sight"],
+		"uniques": [
+			"[+1] Sight",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Mounted", "Scout", "Helicopter", "Melee Water"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -376,7 +437,10 @@
 	{
 		"name": "Shock",
 		"prerequisites": ["Combat I", "Drill I"],
-		"uniques": ["[+25]% Strength <vs [Melee] units>"],
+		"uniques": [
+			"[+25]% Strength <vs [Melee] units>",
+			"[This Unit] heals [25] HP <hidden from users>"
+		],
 		"unitTypes": ["Archery", "Mounted", "Sword", "Siege"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
@@ -385,7 +449,8 @@
 		"name": "Woodsman I",
 		"uniques": [
 			"[+20]% Strength <when fighting in [Jungle] tiles> <when defending>",
-			"[+20]% Strength <when fighting in [Forest] tiles> <when defending>"
+			"[+20]% Strength <when fighting in [Forest] tiles> <when defending>",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Scout", "Sword", "Gunpowder"],
 		"outerColor": [12, 74, 146],
@@ -398,22 +463,12 @@
 			"[+30]% Strength <when fighting in [Jungle] tiles> <when defending>",
 			"[+30]% Strength <when fighting in [Forest] tiles> <when defending>",
 			"Double movement in [Jungle]",
-			"Double movement in [Forest]"
+			"Double movement in [Forest]",
+			"[This Unit] heals [25] HP <hidden from users>"
 		],
 		"unitTypes": ["Scout", "Sword", "Gunpowder"],
 		"outerColor": [12, 74, 146],
 		"innerColor": [219, 152, 13]
-	},
-
-	{
-		"name": "Heal Instantly",
-		"uniques": [
-			"[This Unit] heals [50] HP",
-			"Doing so will consume this opportunity to choose a Promotion"
-		],
-		"innerColor": [195,53,43],
-		"outerColor": [253,236,234],
-		"unitTypes": ["Sword","Gunpowder","Mounted","Scout","Siege","Archery","Ranged Gunpowder","Armored","Melee Water","Ranged Water","Submarine"]
 	},
 
 	// For barbarian water units

--- a/jsons/UnitTypes.json
+++ b/jsons/UnitTypes.json
@@ -1,56 +1,96 @@
+// TODO: Make [This Unit] heals [25] HP <upon being promoted>
 [
   {
     "name": "Civilian",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Sword",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Gunpowder",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Archery",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Ranged Gunpowder",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Scout",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Mounted",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Armored",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Siege",
-    "movementType": "Land"
+    "movementType": "Land",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Civilian Water",
-    "movementType": "Water"
+    "movementType": "Water",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Melee Water",
-    "movementType": "Water"
+    "movementType": "Water",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Ranged Water",
-    "movementType": "Water"
+    "movementType": "Water",
+	"uniques": [
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
     "name": "Submarine",
     "movementType": "Water",
-    "uniques": ["Invisible to non-adjacent units", "Can see invisible [Submarine] units"]
+    "uniques": [
+		"Invisible to non-adjacent units",
+		"Can see invisible [Submarine] units",
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"]
   },
   {
     "name": "Fighter",
@@ -59,7 +99,8 @@
 		//"Aircraft",
 		"[+4] Sight",
 		"Can see over obstacles",
-		"Can perform Air Sweep"
+		"Can perform Air Sweep",
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
 	]
   },
   {
@@ -67,19 +108,24 @@
     "movementType": "Air",
 	"uniques": [
 		//"Aircraft"
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
 	]
   },
   {
     "name": "Helicopter",
     "movementType": "Land",
-    "uniques": ["Can pass through impassable tiles"]
+    "uniques": [
+		"Can pass through impassable tiles",
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
+	]
   },
   {
 	"name": "Missle",
 	"movementType": "Air",
 	"uniques": [
 		"Self-destructs when attacking",
-		"Cannot be intercepted"
+		"Cannot be intercepted",
+		"[This Unit] heals [25] HP <upon being promoted> <hidden from users>"
 	]
   },
   {


### PR DESCRIPTION
There is no Heal Instantly promotion. Instead each promotion heals by half of the missing HP.
