### PR TITLE
Update Optics to allow entering ocean

### DIFF
--- a/jsons/Techs.json
+++ b/jsons/Techs.json
@@ -463,7 +463,8 @@
 				"row": 11,
 				"prerequisites": ["Compass", "Machinery"],
 				"uniques": [
-					"[+1] Sight <for [Water] units>"
+					"[+1] Sight <for [Water] units>",
+					"Enables [Embarked] units to enter ocean tiles" // TODO: Civ IV doesn't have Embark. Optimally, we would use Carry [Land] units instead.
 				],
 				"quote": "\"One doesn't discover new lands without losing sight of the shore.\" - Andre Gide"
 			}

--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -232,14 +232,13 @@
 		"techRequired": "Combustion",
 		"uniques": [
 			"Can only be built to improve a resource",
-			"Cannot be built on [Coast] tiles <before discovering [Plastics]>",
 			"Pillaging this improvement yields approximately [+10 Gold]"
 		],
 		"shortcutKey": "W"
 	},
 	{
 		"name": "Whaling Boats",
-		"terrainsCanBeBuiltOn": ["Coast"],
+		"terrainsCanBeBuiltOn": ["Ocean"],
 		"techRequired": "Optics",
 		"food": 5,
 		"uniques": [

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1056,7 +1056,8 @@
 			"Can build [Land] improvements on tiles",
 			"Cannot attack",
 			"Automation is a primary action",
-			"Excess Food converted to Production when under construction"
+			"Excess Food converted to Production when under construction",
+			"Cannot enter ocean tiles"
 		],
 		"hurryCostModifier": 20
 	},
@@ -1072,7 +1073,7 @@
 			"Can instantly construct a [Whaling Boats] improvement <by consuming this unit> <after discovering [Optics]>",
 			"Never appears as a Barbarian unit",
 			"Cannot attack",
-			"Cannot enter ocean tiles <before discovering [Astronomy]>"
+			"Cannot enter ocean tiles <before discovering [Optics]>"
 		]
 	},
 


### PR DESCRIPTION
@Kzer-Za The problem we have is that Civ IV doesn't really have a concept of Embark. Unciv doesn't have "Carry [Land] units" yet, so we need to add embarks for now.

Also, to my knowledge, Galleys, Ironclad, Triremes can't enter oceans whether or not you have the tech. I could be wrong though, mind checking in the original game?

https://civilization.fandom.com/wiki/Naval_unit_(Civ4)

Fixes #79

