### PR TITLE
Make Forts unbuildable in foreigni terriroties

### DIFF
--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -113,6 +113,7 @@
 		"turnsToBuild": 10,
 		"techRequired": "Mathematics",
 		"uniques": [
+			"Unbuildable <on foreign continents>",
 	        "Can be built outside your borders",
 			"Tile provides yield without assigned population",
 			"Gives a defensive bonus of [25]%"


### PR DESCRIPTION
> Forts cannot be built in foreign territory. They can, however, be built in neutral territory, and of course within a civ's own territory. Forts may be built on any [tile](https://civilization.fandom.com/wiki/Tile_(Civ4)) except [oasis](https://civilization.fandom.com/wiki/Terrain_(Civ4)) tiles. Building a Fort removes any other tile improvement present except for a [road](https://civilization.fandom.com/wiki/Roads_and_railroads_(Civ4)) or [railroad](https://civilization.fandom.com/wiki/Roads_and_railroads_(Civ4)).

Using `"Unbuildable <on foreign continents>"` doesn't do it.